### PR TITLE
Escape quotation marks in Map2Char

### DIFF
--- a/autoload/tinykeymap.vim
+++ b/autoload/tinykeymap.vim
@@ -303,6 +303,7 @@ endf
 function! s:Map2Char(key) "{{{3
     let keycode = escape(a:key, '\')
     let keycode = substitute(keycode, '<', '\\<', 'g')
+    let keycode = substitute(keycode, '"', '\\"', 'g')
     let keycode = eval('"'. keycode .'"')
     return keycode
 endf


### PR DESCRIPTION
Because we use quotation marks to evaluate the keycode, we need to escape the quotation marks in the keycode. This fixes issue #8.

```vim
    let keycode = substitute(keycode, '"', '\\"', 'g') " added
    let keycode = eval('"'. keycode .'"')
```